### PR TITLE
Use `btn-{color}` classes to improve color contrast

### DIFF
--- a/src/KristofferStrube.EditorConfigWizard/Pages/Wizard.razor
+++ b/src/KristofferStrube.EditorConfigWizard/Pages/Wizard.razor
@@ -80,11 +80,11 @@
                     </h3>
                 </div>
                 <div style="display:flex;flex-wrap:wrap;justify-content:center;width:100%;gap:5px;">
-                    <button @onclick=@(() => SetSeverity("none")) class="btn btn-lg bg-light">None</button>
-                    <button @onclick=@(() => SetSeverity("silent")) class="btn btn-lg bg-secondary">Silent</button>
-                    <button @onclick=@(() => SetSeverity("suggestion")) class="btn btn-lg bg-primary">Suggestion</button>
-                    <button @onclick=@(() => SetSeverity("warning")) class="btn btn-lg bg-warning">Warning</button>
-                    <button @onclick=@(() => SetSeverity("error")) class="btn btn-lg bg-danger">Error</button>
+                    <button @onclick=@(() => SetSeverity("none")) class="btn btn-lg btn-light">None</button>
+                    <button @onclick=@(() => SetSeverity("silent")) class="btn btn-lg btn-secondary">Silent</button>
+                    <button @onclick=@(() => SetSeverity("suggestion")) class="btn btn-lg btn-primary">Suggestion</button>
+                    <button @onclick=@(() => SetSeverity("warning")) class="btn btn-lg btn-warning">Warning</button>
+                    <button @onclick=@(() => SetSeverity("error")) class="btn btn-lg btn-danger">Error</button>
                 </div>
                 @if (currentCodeStyleRule.Sample is { Length: > 0 } sample)
                 {

--- a/src/KristofferStrube.EditorConfigWizard/Shared/OrderedSetWithOneOrMoreOfManyValueOptionsPicker.razor
+++ b/src/KristofferStrube.EditorConfigWizard/Shared/OrderedSetWithOneOrMoreOfManyValueOptionsPicker.razor
@@ -12,9 +12,9 @@
                 <code style="display:flex;flex:1;justify-content:right;">@value</code>
             </div>
             <div style="display:flex; flex-direction:row;gap:5px;">
-                <span @onclick="() => MoveLeft(value)" class="btn btn-sm bg-primary flex1">&#60;</span>
-                <span @onclick="() => Remove(value)" class="btn btn-sm bg-danger flex1">X</span>
-                <span @onclick="() => MoveRight(value)" class="btn btn-sm bg-primary flex1">&#62;</span>
+                <span @onclick="() => MoveLeft(value)" class="btn btn-sm btn-primary flex1">&#60;</span>
+                <span @onclick="() => Remove(value)" class="btn btn-sm btn-danger flex1">X</span>
+                <span @onclick="() => MoveRight(value)" class="btn btn-sm btn-primary flex1">&#62;</span>
             </div>
         </div>
     }
@@ -28,7 +28,7 @@
             <div style="background-color:#272822;border-radius:5px;padding:5px;min-width:110px;display:flex;flex-direction:column;">
                 <code style="display:flex;flex:1;justify-content:center;">@value</code>
                 <div style="display:flex; flex-direction:row;gap:5px;">
-                    <span @onclick="() => Add(value)" class="btn btn-sm bg-success flex1">+</span>
+                    <span @onclick="() => Add(value)" class="btn btn-sm btn-success flex1">+</span>
                 </div>
             </div>
         }


### PR DESCRIPTION
Currently, three of the wizard buttons have poor color contrast. This PR fixes by using Bootstrap's `btn-{color}` classes instead of just background utilities.

## Before and After

Current:

<img width="1728" alt="Screenshot 2023-02-19 at 12 08 02" src="https://user-images.githubusercontent.com/9486206/219946976-d6489d30-a68c-4618-9d69-905ecff48163.png">

PR:
<img width="1728" alt="Screenshot 2023-02-19 at 12 07 30" src="https://user-images.githubusercontent.com/9486206/219946968-a5a999fa-c28f-4e89-9d70-b82872c08135.png">
