### PR TITLE
Make the code samples buttons

### DIFF
--- a/src/KristofferStrube.EditorConfigWizard/Shared/HighLightedCode.razor
+++ b/src/KristofferStrube.EditorConfigWizard/Shared/HighLightedCode.razor
@@ -1,16 +1,31 @@
 ﻿@using System.Text
 @inject IJSRuntime JSRuntime
 
-<pre @onclick="InvokeAction" class="@preClass" style="cursor: @cursor">
-    <code @ref="@codeBlock" class="@Language" style="border-radius:5px;font-size:18px;">
-        @Code.Trim()
-    </code>
-</pre>
+@if (OnClick is not null)
+{ 
+    <button @onclick="InvokeAction" class="@commonClasses @hoverClasses">
+        <pre>
+            <code @ref="@codeBlock" class="@Language" style="border-radius:5px;font-size:18px;">
+                @Code.Trim()
+            </code>
+        </pre>
+    </button>
+}
+else
+{
+    <pre class="@commonClasses">
+        <code @ref="@codeBlock" class="@Language" style="border-radius:5px;font-size:18px;">
+            @Code.Trim()
+        </code>
+    </pre>
+}
 
 @code {
     private ElementReference codeBlock;
-    private string? preClass;
-    private string cursor = "";
+
+    private string commonClasses = "text-start";
+
+    private string? hoverClasses;
 
     [Parameter, EditorRequired]
     public string Code { get; set; } = "";
@@ -29,8 +44,6 @@
 
     protected override void OnParametersSet()
     {
-        cursor = OnClick is not null ? "pointer" : "default";
-
         var hasHover = BorderHoverColor is not null || BorderColor is not null;
 
         if (hasHover)
@@ -47,7 +60,7 @@
             }
 
             sb.Append("hasHover");
-            preClass = sb.ToString();
+            hoverClasses = sb.ToString();
         }
     }
 

--- a/src/KristofferStrube.EditorConfigWizard/Shared/HighLightedCode.razor.css
+++ b/src/KristofferStrube.EditorConfigWizard/Shared/HighLightedCode.razor.css
@@ -2,11 +2,22 @@
     border: 4px solid transparent;
 }
 
+button {
+    background: none !important;
+    padding: 0 !important;
+    border-radius: 14px !important;
+    width: 100% !important;
+}
+
 pre {
-    border-radius: 13px;
+    border-radius: 10px; /* border-radius of button minus border-width of .hasHover */
+    margin-inline: 0;
+    margin-block: 0.5rem;
+    width: 100%;
+}
+
+button pre {
     margin: 0;
-    margin-bottom: 8px;
-    margin-top: 8px;
 }
 
 code {

--- a/src/KristofferStrube.EditorConfigWizard/Shared/HighLightedCode.razor.css
+++ b/src/KristofferStrube.EditorConfigWizard/Shared/HighLightedCode.razor.css
@@ -28,12 +28,33 @@ code {
     border: 4px solid red;
 }
 
+.red-hover:focus {
+    outline-color: red;
+    outline-style: solid;
+    outline-offset: -4px;
+    outline-width: 4px;
+}
+
 .green-hover:hover {
     border: 4px solid green;
 }
 
+.green-hover:focus {
+    outline-color: green;
+    outline-style: solid;
+    outline-offset: -4px;
+    outline-width: 4px;
+}
+
 .yellow-hover:hover {
     border: 4px solid orange;
+}
+
+.yellow-hover:focus {
+    outline-color: orange;
+    outline-style: solid;
+    outline-offset: -4px;
+    outline-width: 4px;
 }
 
 .red {


### PR DESCRIPTION
This is a better way to achieve what I originally did in 4cb2c91e65857c7dcfaaf1f87306881231871405. Can now tab over the samples when clickable too.